### PR TITLE
Make sure users cannot move pawns to attach off the side of the board

### DIFF
--- a/app/move-options.test.ts
+++ b/app/move-options.test.ts
@@ -43,6 +43,27 @@ it("does not allow a black pawn to move forward an capture their own piece to it
   expect(calculateGamePieceMoves("blk-p3", state)).toEqual([18]);
 });
 
+//
+it("does not allow a black pawn to move forward an capture a pieceoff the left side of the board", () => {
+  const state = {
+    ...initialState,
+    "blk-p1": 16,
+    'wh-p8': 23,
+  };
+
+  expect(calculateGamePieceMoves("blk-p1", state)).toEqual([24]);
+});
+
+it("does not allow a black pawn to move forward an capture a pieceoff the right side of the board", () => {
+  const state = {
+    ...initialState,
+    'blk-p8': 23,
+    'wh-p1': 32,
+  };
+
+  expect(calculateGamePieceMoves("blk-p8", state)).toEqual([31]);
+});
+
 it("allows a white pawn to move forward", () => {
   expect(calculateGamePieceMoves("wh-p1", initialState)).toEqual([40]);
 });
@@ -81,4 +102,24 @@ it("does not allow a white pawn to move forward an capture their own piece to it
   };
 
   expect(calculateGamePieceMoves("wh-p6", state)).toEqual([45]);
+});
+
+it("does not allow a white pawn to move forward an capture a pieceoff the left side of the board", () => {
+  const state = {
+    ...initialState,
+    "wh-p1": 40,
+    'blk-p8': 31
+  };
+
+  expect(calculateGamePieceMoves("wh-p1", state)).toEqual([32]);
+});
+
+it("does not allow a white pawn to move forward an capture a pieceoff the right side of the board", () => {
+  const state = {
+    ...initialState,
+    "wh-p8": 47,
+    'blk-p1': 40
+  };
+
+  expect(calculateGamePieceMoves("wh-p8", state)).toEqual([39]);
 });

--- a/app/move-options.ts
+++ b/app/move-options.ts
@@ -1,6 +1,7 @@
 import { PieceId } from "./components/GamePiece";
+import { isOnLeftBoundary, isOnRightBoundary } from "./boundary-checks";
 
-const colorRegEx = /^(blk|wh)-.*$/
+const colorRegEx = /^(blk|wh)-.*$/;
 const pawnRegex = /^(blk|wh)-p([1-8])$/;
 
 /** Calculate the spaces a piece can move to */
@@ -17,92 +18,100 @@ export function calculateGamePieceMoves(
 
 /** Determines which postitions a pawn can move to */
 function movePawn(pieceId: PieceId, gameState: Record<PieceId, number>) {
-  const currentPosition = gameState[pieceId]
-  const pawnMatch = pawnRegex.exec(pieceId)
+  const currentPosition = gameState[pieceId];
+  const pawnMatch = pawnRegex.exec(pieceId);
 
   // This should not happen. Make sure we handle this
   if (pawnMatch === null) {
-    throw new Error('No pawn match found')
+    throw new Error("No pawn match found");
   }
 
-  const [_, color] = pawnMatch
+  const [_, color] = pawnMatch;
 
-  const invertedPieces = new Map(Array.from(
-    Object.entries(gameState) as [PieceId, number][]
-  ).map<[number, PieceId]>(([k, v]) => [v, k]));
-
-  const pieceMap = new Map(invertedPieces);
+  const invertedPieces = new Map(
+    Array.from(Object.entries(gameState) as [PieceId, number][]).map<
+      [number, PieceId]
+    >(([k, v]) => [v, k])
+  );
 
   if (color === "blk") {
-    const onePositionForward = currentPosition + 8
-    const positions = [onePositionForward]
+    const onePositionForward = currentPosition + 8;
+    const positions = [onePositionForward];
 
-    const pieceToLeft = invertedPieces.get(onePositionForward - 1)
-    if (pieceToLeft) {
-      const x = colorRegEx.exec(pieceToLeft)
+    // Don't try to capture to the left if we're on the left boundary
+    if (!isOnLeftBoundary(currentPosition)) {
+      const pieceToLeft = invertedPieces.get(onePositionForward - 1);
+      if (pieceToLeft) {
+        const x = colorRegEx.exec(pieceToLeft);
 
-      if (x !== null) {
-        const [_, leftPieceColor] = x
+        if (x !== null) {
+          const [_, leftPieceColor] = x;
 
-        // If it's not the same color, we can move there
-        if (leftPieceColor !== color) {
-          positions.push(onePositionForward - 1)
+          // If it's not the same color, we can move there
+          if (leftPieceColor !== color) {
+            positions.push(onePositionForward - 1);
+          }
         }
       }
     }
 
-    const pieceToRight = invertedPieces.get(onePositionForward + 1)
-    if (pieceToRight) {
-      const x = colorRegEx.exec(pieceToRight)
-
-      if (x !== null) {
-        const [_, rightPieceColor] = x
-
-        // If it's not the same color, we can move there
-        if (rightPieceColor !== color) {
-          positions.push(onePositionForward + 1)
+    if (!isOnRightBoundary(currentPosition)) {
+      const pieceToRight = invertedPieces.get(onePositionForward + 1);
+      if (pieceToRight) {
+        const x = colorRegEx.exec(pieceToRight);
+  
+        if (x !== null) {
+          const [_, rightPieceColor] = x;
+  
+          // If it's not the same color, we can move there
+          if (rightPieceColor !== color) {
+            positions.push(onePositionForward + 1);
+          }
         }
       }
+  
     }
-
+    
     return positions;
   }
 
   if (color === "wh") {
-    const onePositionForward = currentPosition - 8
-    const positions = [currentPosition - 8]
+    const onePositionForward = currentPosition - 8;
+    const positions = [currentPosition - 8];
 
-    // TODO: Deterine if their at a left boundary, right boundary, top boundary, bottom bondary
-
-    // TODO: Determine if they're at the left boundary
-    const pieceToLeft = invertedPieces.get(onePositionForward - 1)
-    if (pieceToLeft) {
-      const x = colorRegEx.exec(pieceToLeft)
-
-      if (x !== null) {
-        const [_, leftPieceColor] = x
-
-        // If it's not the same color, we can move there
-        if (leftPieceColor !== color) {
-          positions.push(onePositionForward - 1)
+    if (!isOnLeftBoundary(currentPosition)) {
+      const pieceToLeft = invertedPieces.get(onePositionForward - 1);
+      if (pieceToLeft) {
+        const x = colorRegEx.exec(pieceToLeft);
+  
+        if (x !== null) {
+          const [_, leftPieceColor] = x;
+  
+          // If it's not the same color, we can move there
+          if (leftPieceColor !== color) {
+            positions.push(onePositionForward - 1);
+          }
         }
       }
     }
+    
 
-    const pieceToRight = invertedPieces.get(onePositionForward + 1)
-    if (pieceToRight) {
-      const x = colorRegEx.exec(pieceToRight)
-
-      if (x !== null) {
-        const [_, rightPieceColor] = x
-
-        // If it's not the same color, we can move there
-        if (rightPieceColor !== color) {
-          positions.push(onePositionForward + 1)
+    if (!isOnRightBoundary(currentPosition)) {
+      const pieceToRight = invertedPieces.get(onePositionForward + 1);
+      if (pieceToRight) {
+        const x = colorRegEx.exec(pieceToRight);
+  
+        if (x !== null) {
+          const [_, rightPieceColor] = x;
+  
+          // If it's not the same color, we can move there
+          if (rightPieceColor !== color) {
+            positions.push(onePositionForward + 1);
+          }
         }
       }
     }
-
+    
 
     return positions;
   }


### PR DESCRIPTION
## What's new

This updates uses `isOnLeftBoundary` & `isOnRightBoundary` to check where a pawn is at on the board before allowing it to capture another piece.