### PR TITLE
Calculate legal moves on piece drop

### DIFF
--- a/app/components/Gameboard.tsx
+++ b/app/components/Gameboard.tsx
@@ -73,7 +73,6 @@ export const Gameboard: React.FC<GameboardProps> = (props) => {
     (pos) => (evt) => {
       // I'm type casting here because I know what I set
       const pieceId = evt.dataTransfer.getData("text/plain") as PieceId
-
       const legalMoves = calculateGamePieceMoves(pieceId, piecePositions)
       
       // If the piece was dropped on a legal space then update the game board


### PR DESCRIPTION
## What's new

This update will check to make sure the the piece is being dropped on a legal space. If legal, the game board state will be updated. If not legal the board will revert.