### PR TITLE
Fix bug allowing pawn to capture forward

### DIFF
--- a/app/move-options.test.ts
+++ b/app/move-options.test.ts
@@ -64,6 +64,16 @@ it("does not allow a black pawn to move forward an capture a pieceoff the right 
   expect(calculateGamePieceMoves("blk-p8", state)).toEqual([31]);
 });
 
+it("does not allow a black pawn to move forward an capture a pieceoff straight ahead", () => {
+  const state = {
+    ...initialState,
+    'blk-p8': 23,
+    'wh-p8': 31,
+  };
+
+  expect(calculateGamePieceMoves("blk-p8", state)).toEqual([]);
+});
+
 it("allows a white pawn to move forward", () => {
   expect(calculateGamePieceMoves("wh-p1", initialState)).toEqual([40]);
 });
@@ -122,4 +132,13 @@ it("does not allow a white pawn to move forward an capture a pieceoff the right 
   };
 
   expect(calculateGamePieceMoves("wh-p8", state)).toEqual([39]);
+});
+
+it("does not allow a white pawn to move forward an capture a pieceoff straight ahead", () => {
+  const state = {
+    ...initialState,
+    'blk-p4': 43,
+  };
+
+  expect(calculateGamePieceMoves("wh-p4", state)).toEqual([]);
 });

--- a/app/move-options.ts
+++ b/app/move-options.ts
@@ -36,7 +36,10 @@ function movePawn(pieceId: PieceId, gameState: Record<PieceId, number>) {
 
   if (color === "blk") {
     const onePositionForward = currentPosition + 8;
-    const positions = [onePositionForward];
+    
+    // If there is a piece in the position directly in front of the pawn, then
+    // do not allow them to move one position forward
+    const positions = invertedPieces.has(onePositionForward) ? [] : [onePositionForward];
 
     // Don't try to capture to the left if we're on the left boundary
     if (!isOnLeftBoundary(currentPosition)) {
@@ -77,7 +80,10 @@ function movePawn(pieceId: PieceId, gameState: Record<PieceId, number>) {
 
   if (color === "wh") {
     const onePositionForward = currentPosition - 8;
-    const positions = [currentPosition - 8];
+
+    // If there is a piece in the position directly in front of the pawn, then
+    // do not allow them to move one position forward
+    const positions = invertedPieces.has(onePositionForward) ? [] : [currentPosition - 8];
 
     if (!isOnLeftBoundary(currentPosition)) {
       const pieceToLeft = invertedPieces.get(onePositionForward - 1);


### PR DESCRIPTION
## What's new

This change fixes a bug that allowed pawns to move forward and capture pieces directly ahead