### PR TITLE
Fix reset state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,6 +69,9 @@ function reducer(state: State, action: Action): State {
     return {
       ...state,
       activePieces: initialState,
+      capturedPieces: [],
+      inCheck: null,
+      inCheckMate: false,
       turn: "white",
     };
   }


### PR DESCRIPTION
## What's new

This change fixes an issue that prevented all game state from being reset when the same was reset.

The data that didn't get updated correctly was
- capture pieces
- check/checkmate status